### PR TITLE
Cat 1 - Consume Frequency CRUD

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,3 +19,8 @@ model RiskLevel {
   id   String @id @default(auto()) @map("_id") @db.ObjectId
   name String @unique
 }
+
+model ConsumeFrequency {
+  id        String @id @default(auto()) @map("_id") @db.ObjectId
+  frequency String @unique
+}

--- a/request.http
+++ b/request.http
@@ -41,3 +41,25 @@ content-type: application/json
 }
 ### DELETE
 DELETE http://localhost:3002/risk-level/635d9dbd93b2bfccf5164bfd HTTP/1.1
+###
+### Consume Frequency
+### GET ALL
+GET http://localhost:3002/consume-frequency HTTP/1.1
+### GET BY ID
+GET http://localhost:3002/consume-frequency/635de6e68e238e5869b21651 HTTP/1.1
+### CREATE 
+POST http://localhost:3002/consume-frequency HTTP/1.1
+content-type: application/json
+
+{
+    "frequency": "5 per day"
+}
+### UPDATE
+PUT http://localhost:3002/consume-frequency/635de6ee8e238e5869b21652 HTTP/1.1
+content-type: application/json
+
+{
+    "frequency": "Moderation"
+}
+### DELETE
+DELETE http://localhost:3002/consume-frequency/635de6e68e238e5869b21651 HTTP/1.1

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,9 +5,16 @@ import { ConfigModule } from './config/config.module';
 import { PrismaModule } from './shared/services/prisma/prisma.module';
 import { CategoryModule } from './modules/category/category.module';
 import { RiskLevelModule } from './modules/risk-level/risk-level.module';
+import { ConsumeFrequencyModule } from './modules/consume-frequency/consume-frequency.module';
 
 @Module({
-  imports: [ConfigModule, PrismaModule, CategoryModule, RiskLevelModule],
+  imports: [
+    ConfigModule,
+    PrismaModule,
+    CategoryModule,
+    RiskLevelModule,
+    ConsumeFrequencyModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/modules/consume-frequency/consume-frequency.controller.spec.ts
+++ b/src/modules/consume-frequency/consume-frequency.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConsumeFrequencyController } from './consume-frequency.controller';
+
+describe('ConsumeFrequencyController', () => {
+  let controller: ConsumeFrequencyController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ConsumeFrequencyController],
+    }).compile();
+
+    controller = module.get<ConsumeFrequencyController>(
+      ConsumeFrequencyController,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/consume-frequency/consume-frequency.controller.spec.ts
+++ b/src/modules/consume-frequency/consume-frequency.controller.spec.ts
@@ -1,20 +1,145 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConsumeFrequencyController } from './consume-frequency.controller';
+import { ConsumeFrequencyService } from './consume-frequency.service';
+import { CreateConsumeFrequencyDto, UpdateConsumeFrequencyDto } from './dtos';
 
 describe('ConsumeFrequencyController', () => {
   let controller: ConsumeFrequencyController;
+  let consumeFrequencyService: ConsumeFrequencyService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ConsumeFrequencyController],
+      providers: [
+        {
+          provide: ConsumeFrequencyService,
+          useValue: {
+            getConsumeFrequencies: jest.fn(),
+            getConsumeFrequencyById: jest.fn(),
+            createConsumeFrequency: jest.fn(),
+            updateConsumeFrequency: jest.fn(),
+            deleteConsumeFrequencyById: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<ConsumeFrequencyController>(
       ConsumeFrequencyController,
     );
+    consumeFrequencyService = module.get<ConsumeFrequencyService>(
+      ConsumeFrequencyService,
+    );
   });
+
+  afterEach(() => jest.clearAllMocks());
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('#getConsumeFrequencies', () => {
+    it('should return all consume frequencies from db', async () => {
+      const expectedResponse = [
+        {
+          id: '1',
+          frequency: 'Frequency 1',
+        },
+      ];
+      const getConsumeFrequenciesSpy = jest
+        .spyOn(consumeFrequencyService, 'getConsumeFrequencies')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await controller.getConsumeFrequencies();
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(getConsumeFrequenciesSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('#getConsumeFrequency', () => {
+    it('should get a specific consume frequency from db based in the argument given', async () => {
+      const params = { id: '123' };
+      const expectedResponse = {
+        id: params.id,
+        frequency: 'Frequency 123',
+      };
+      const getConsumeFrequencyByIdSpy = jest
+        .spyOn(consumeFrequencyService, 'getConsumeFrequencyById')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await controller.getConsumeFrequency(params.id);
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(getConsumeFrequencyByIdSpy).toHaveBeenCalled();
+      expect(getConsumeFrequencyByIdSpy).toHaveBeenCalledWith(params.id);
+    });
+  });
+
+  describe('#createConsumeFrequency', () => {
+    it('should create a new consume frequency in the db', async () => {
+      const params = {
+        frequency: 'New Frequency',
+      } as CreateConsumeFrequencyDto;
+      const expectedResponse = { id: '123456', frequency: params.frequency };
+      const createConsumeFrequencySpy = jest
+        .spyOn(consumeFrequencyService, 'createConsumeFrequency')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await controller.createConsumeFrequency(params);
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(createConsumeFrequencySpy).toHaveBeenCalled();
+      expect(createConsumeFrequencySpy).toHaveBeenCalledWith(params.frequency);
+    });
+  });
+
+  describe('#updateConsumeFrequency', () => {
+    it('should update a consume frequency from db based in the id given as argument', async () => {
+      const paramId = 'abc789';
+      const paramsBody = {
+        frequency: 'Updated Frequency',
+      } as UpdateConsumeFrequencyDto;
+      const expectedResponse = { id: paramId, frequency: paramsBody.frequency };
+      const updateConsumeFrequencySpy = jest
+        .spyOn(consumeFrequencyService, 'updateConsumeFrequency')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await controller.updateConsumeFrequency(
+        paramId,
+        paramsBody,
+      );
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(updateConsumeFrequencySpy).toHaveBeenCalled();
+      expect(updateConsumeFrequencySpy).toHaveBeenCalledWith(
+        paramId,
+        paramsBody.frequency,
+      );
+    });
+  });
+
+  describe('#deleteConsumeFrequency', () => {
+    it('should delete a specific consume frequency from db based in the argument given', async () => {
+      const params = { id: '12gg34gg' };
+      const expectedResponse = {
+        id: params.id,
+        frequency: 'Frequency deleted',
+      };
+      const deleteConsumeFrequencyByIdSpy = jest
+        .spyOn(consumeFrequencyService, 'deleteConsumeFrequencyById')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await controller.deleteConsumeFrequency(params.id);
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(deleteConsumeFrequencyByIdSpy).toHaveBeenCalled();
+      expect(deleteConsumeFrequencyByIdSpy).toHaveBeenCalledWith(params.id);
+    });
   });
 });

--- a/src/modules/consume-frequency/consume-frequency.controller.ts
+++ b/src/modules/consume-frequency/consume-frequency.controller.ts
@@ -1,4 +1,48 @@
-import { Controller } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+} from '@nestjs/common';
+import { ConsumeFrequencyService } from './consume-frequency.service';
+import { CreateConsumeFrequencyDto, UpdateConsumeFrequencyDto } from './dtos';
 
 @Controller('consume-frequency')
-export class ConsumeFrequencyController {}
+export class ConsumeFrequencyController {
+  constructor(
+    private readonly consumeFrequencyService: ConsumeFrequencyService,
+  ) {}
+
+  @Get()
+  public async getConsumeFrequencies() {
+    return this.consumeFrequencyService.getConsumeFrequencies();
+  }
+
+  @Get('/:id')
+  public async getConsumeFrequency(@Param('id') id: string) {
+    return this.consumeFrequencyService.getConsumeFrequencyById(id);
+  }
+
+  @Post()
+  public async createConsumeFrequency(
+    @Body() { frequency }: CreateConsumeFrequencyDto,
+  ) {
+    return this.consumeFrequencyService.createConsumeFrequency(frequency);
+  }
+
+  @Put('/:id')
+  public async updateConsumeFrequency(
+    @Param('id') id: string,
+    @Body() { frequency }: UpdateConsumeFrequencyDto,
+  ) {
+    return this.consumeFrequencyService.updateConsumeFrequency(id, frequency);
+  }
+
+  @Delete('/:id')
+  public async deleteConsumeFrequency(@Param('id') id: string) {
+    return this.consumeFrequencyService.deleteConsumeFrequencyById(id);
+  }
+}

--- a/src/modules/consume-frequency/consume-frequency.controller.ts
+++ b/src/modules/consume-frequency/consume-frequency.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('consume-frequency')
+export class ConsumeFrequencyController {}

--- a/src/modules/consume-frequency/consume-frequency.module.ts
+++ b/src/modules/consume-frequency/consume-frequency.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../../shared/services/prisma/prisma.module';
+import { ConsumeFrequencyController } from './consume-frequency.controller';
+import { ConsumeFrequencyService } from './consume-frequency.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ConsumeFrequencyController],
+  providers: [ConsumeFrequencyService],
+})
+export class ConsumeFrequencyModule {}

--- a/src/modules/consume-frequency/consume-frequency.service.spec.ts
+++ b/src/modules/consume-frequency/consume-frequency.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConsumeFrequencyService } from './consume-frequency.service';
+
+describe('ConsumeFrequencyService', () => {
+  let service: ConsumeFrequencyService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ConsumeFrequencyService],
+    }).compile();
+
+    service = module.get<ConsumeFrequencyService>(ConsumeFrequencyService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/consume-frequency/consume-frequency.service.spec.ts
+++ b/src/modules/consume-frequency/consume-frequency.service.spec.ts
@@ -1,18 +1,137 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../shared/services/prisma/prisma.service';
 import { ConsumeFrequencyService } from './consume-frequency.service';
 
 describe('ConsumeFrequencyService', () => {
   let service: ConsumeFrequencyService;
+  let prismaService: PrismaService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ConsumeFrequencyService],
+      providers: [
+        ConsumeFrequencyService,
+        {
+          provide: PrismaService,
+          useValue: {
+            consumeFrequency: {
+              findMany: jest.fn(),
+              findFirst: jest.fn(),
+              create: jest.fn(),
+              update: jest.fn(),
+              delete: jest.fn(),
+            },
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<ConsumeFrequencyService>(ConsumeFrequencyService);
+    prismaService = module.get<PrismaService>(PrismaService);
   });
+
+  afterEach(() => jest.clearAllMocks());
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('#getConsumeFrequencies', () => {
+    it('should return all consumer frequencies from db', async () => {
+      const expectedResponse = [
+        {
+          id: 'a12c3e',
+          frequency: '1 per day',
+        },
+      ];
+      const findManySpy = jest
+        .spyOn(prismaService.consumeFrequency, 'findMany')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await service.getConsumeFrequencies();
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(findManySpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('#getConsumeFrequencyById', () => {
+    it('should return a specific consume frequency from db by id given as argument', async () => {
+      const params = { id: '1ab2' };
+      const expectedResponse = { id: params.id, frequency: '2 per day' };
+
+      const findFirstSpy = jest
+        .spyOn(prismaService.consumeFrequency, 'findFirst')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await service.getConsumeFrequencyById(params.id);
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(findFirstSpy).toHaveBeenCalled();
+      expect(findFirstSpy).toHaveBeenCalledWith({ where: { id: params.id } });
+    });
+  });
+
+  describe('#createConsumeFrequency', () => {
+    it('should create a new consume frequency in the db based in the properties given as arguments', async () => {
+      const params = { frequency: 'New Frequency' };
+      const expectedResponse = { id: '1a', frequency: params.frequency };
+      const createSpy = jest
+        .spyOn(prismaService.consumeFrequency, 'create')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await service.createConsumeFrequency(params.frequency);
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(createSpy).toHaveBeenCalled();
+      expect(createSpy).toHaveBeenCalledWith({
+        data: { frequency: params.frequency },
+      });
+    });
+  });
+
+  describe('#updateConsumeFrequency', () => {
+    it('should update the properties of a consume frequency from db', async () => {
+      const params = { id: '123', frequency: 'Updated Frequency' };
+      const expectedResponse = { id: params.id, frequency: params.frequency };
+      const updateSpy = jest
+        .spyOn(prismaService.consumeFrequency, 'update')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await service.updateConsumeFrequency(
+        params.id,
+        params.frequency,
+      );
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(updateSpy).toHaveBeenCalled();
+      expect(updateSpy).toBeCalledWith({
+        where: { id: params.id },
+        data: { frequency: params.frequency },
+      });
+    });
+  });
+
+  describe('#deleteConsumeFrequencyById', () => {
+    it('should delete a specific consume frequency from db by id given as argument', async () => {
+      const params = { id: '1234' };
+      const expectedResponse = {
+        id: params.id,
+        frequency: 'Consume Frequency Deleted',
+      };
+      const deleteSpy = jest
+        .spyOn(prismaService.consumeFrequency, 'delete')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await service.deleteConsumeFrequencyById(params.id);
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(deleteSpy).toHaveBeenCalled();
+      expect(deleteSpy).toHaveBeenCalledWith({ where: { id: params.id } });
+    });
   });
 });

--- a/src/modules/consume-frequency/consume-frequency.service.ts
+++ b/src/modules/consume-frequency/consume-frequency.service.ts
@@ -1,4 +1,46 @@
 import { Injectable } from '@nestjs/common';
+import { ConsumeFrequency } from '@prisma/client';
+import { PrismaService } from '../../shared/services/prisma/prisma.service';
 
 @Injectable()
-export class ConsumeFrequencyService {}
+export class ConsumeFrequencyService {
+  private readonly model = this.prismaService.consumeFrequency;
+
+  constructor(private readonly prismaService: PrismaService) {}
+
+  public async getConsumeFrequencies(): Promise<ConsumeFrequency[]> {
+    return this.model.findMany();
+  }
+
+  public async getConsumeFrequencyById(id: string): Promise<ConsumeFrequency> {
+    return this.model.findFirst({ where: { id } });
+  }
+
+  public async createConsumeFrequency(
+    frequency: string,
+  ): Promise<ConsumeFrequency> {
+    return this.model.create({
+      data: {
+        frequency,
+      },
+    });
+  }
+
+  public async updateConsumeFrequency(
+    id: string,
+    frequency: string,
+  ): Promise<ConsumeFrequency> {
+    return this.model.update({
+      where: { id },
+      data: { frequency },
+    });
+  }
+
+  public async deleteConsumeFrequencyById(
+    id: string,
+  ): Promise<ConsumeFrequency> {
+    return this.model.delete({
+      where: { id },
+    });
+  }
+}

--- a/src/modules/consume-frequency/consume-frequency.service.ts
+++ b/src/modules/consume-frequency/consume-frequency.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ConsumeFrequencyService {}

--- a/src/modules/consume-frequency/dtos/create-consume-frequency.dto.ts
+++ b/src/modules/consume-frequency/dtos/create-consume-frequency.dto.ts
@@ -1,0 +1,7 @@
+import { IsDefined, IsString } from 'class-validator';
+
+export class UpdateConsumeFrequencyDto {
+  @IsDefined()
+  @IsString()
+  frequency: string;
+}

--- a/src/modules/consume-frequency/dtos/index.ts
+++ b/src/modules/consume-frequency/dtos/index.ts
@@ -1,0 +1,2 @@
+export * from './create-consume-frequency.dto';
+export * from './update-consume-frequency.dto';

--- a/src/modules/consume-frequency/dtos/update-consume-frequency.dto.ts
+++ b/src/modules/consume-frequency/dtos/update-consume-frequency.dto.ts
@@ -1,0 +1,7 @@
+import { IsDefined, IsString } from 'class-validator';
+
+export class CreateConsumeFrequencyDto {
+  @IsDefined()
+  @IsString()
+  frequency: string;
+}


### PR DESCRIPTION
## Qué?

Se implemento el CRUD para la colección de Consume Frequency

## Cómo?

- Se generaron los módulos, controllers y services asociados
- Se implemento el servicio con los métodos básicos de CRUD
- Se implemento el controlador con endpoints para hacer uso de los métodos del servicio
- Se generaron dtos para los request del usuario al controlador anteriormente mencionado
- Se actualizo el request.http con los nuevos endpoints implementados

## Pruebas/Tests

- Se crearon los unit test para el controller y service

