### PR TITLE
Cat 3 - Severity Scale CRUD

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    'prettier/prettier': ['error', {endOfLine: 'auto'}],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@nestjs/common": "^8.0.0",
         "@nestjs/core": "^8.0.0",
+        "@nestjs/mapped-types": "^1.2.0",
         "@nestjs/platform-express": "^8.0.0",
         "@prisma/client": "^4.5.0",
         "class-transformer": "^0.5.1",
@@ -1673,6 +1674,25 @@
           "optional": true
         },
         "@nestjs/websockets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.2.0.tgz",
+      "integrity": "sha512-NTFwPZkQWsArQH8QSyFWGZvJ08gR+R4TofglqZoihn/vU+ktHEJjMqsIsADwb7XD97DhiD+TVv5ac+jG33BHrg==",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.8 || ^8.0.0 || ^9.0.0",
+        "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0",
+        "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
           "optional": true
         }
       }
@@ -10778,6 +10798,12 @@
         "tslib": "2.4.0",
         "uuid": "8.3.2"
       }
+    },
+    "@nestjs/mapped-types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.2.0.tgz",
+      "integrity": "sha512-NTFwPZkQWsArQH8QSyFWGZvJ08gR+R4TofglqZoihn/vU+ktHEJjMqsIsADwb7XD97DhiD+TVv5ac+jG33BHrg==",
+      "requires": {}
     },
     "@nestjs/platform-express": {
       "version": "8.4.7",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@nestjs/common": "^8.0.0",
     "@nestjs/core": "^8.0.0",
+    "@nestjs/mapped-types": "^1.2.0",
     "@nestjs/platform-express": "^8.0.0",
     "@prisma/client": "^4.5.0",
     "class-transformer": "^0.5.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,3 +24,10 @@ model ConsumeFrequency {
   id        String @id @default(auto()) @map("_id") @db.ObjectId
   frequency String @unique
 }
+
+model SeverityScale {
+  id          String @id @default(auto()) @map("_id") @db.ObjectId
+  name        String @unique
+  description String
+  icon        String
+}

--- a/request.http
+++ b/request.http
@@ -63,3 +63,28 @@ content-type: application/json
 }
 ### DELETE
 DELETE http://localhost:3002/consume-frequency/635de6e68e238e5869b21651 HTTP/1.1
+### Severity Scale
+### GET ALL SEVERITIES
+GET http://localhost:3002/severity-scale HTTP/1.1
+### GET SEVERITY BY ID
+GET http://localhost:3002/severity-scale/636172586a00904c6b70ba20 HTTP/1.1
+### CREATE NEW SEVERITY
+POST http://localhost:3002/severity-scale HTTP/1.1
+content-type: application/json
+
+{
+    "name": "severity scale 1",
+    "description": "i am a severity",
+    "icon": "pretty-icon"
+}
+### UPDATE SEVERITY
+PUT http://localhost:3002/severity-scale/636172586a00904c6b70ba20 HTTP/1.1
+content-type: application/json
+
+{
+    "name": "update severity scale 2",
+    "description": "i am a severity",
+    "icon": "pretty-icon"
+}
+### DELETE CATEGORY
+DELETE http://localhost:3002/severity-scale/636172586a00904c6b70ba20 HTTP/1.1

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { PrismaModule } from './shared/services/prisma/prisma.module';
 import { CategoryModule } from './modules/category/category.module';
 import { RiskLevelModule } from './modules/risk-level/risk-level.module';
 import { ConsumeFrequencyModule } from './modules/consume-frequency/consume-frequency.module';
+import { SeverityScaleModule } from './modules/severity-scale/severity-scale.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { ConsumeFrequencyModule } from './modules/consume-frequency/consume-freq
     CategoryModule,
     RiskLevelModule,
     ConsumeFrequencyModule,
+    SeverityScaleModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/modules/severity-scale/dtos/create-severity-scale.dto.ts
+++ b/src/modules/severity-scale/dtos/create-severity-scale.dto.ts
@@ -1,0 +1,15 @@
+import { IsDefined, IsString } from 'class-validator';
+
+export class CreateSeverityScaleDto {
+  @IsDefined()
+  @IsString()
+  name: string;
+
+  @IsDefined()
+  @IsString()
+  description: string;
+
+  @IsDefined()
+  @IsString()
+  icon: string;
+}

--- a/src/modules/severity-scale/dtos/index.ts
+++ b/src/modules/severity-scale/dtos/index.ts
@@ -1,0 +1,2 @@
+export * from './create-severity-scale.dto';
+export * from './update-severity-scale.dto';

--- a/src/modules/severity-scale/dtos/update-severity-scale.dto.ts
+++ b/src/modules/severity-scale/dtos/update-severity-scale.dto.ts
@@ -1,0 +1,6 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateSeverityScaleDto } from './index';
+
+export class UpdateSeverityScaleDto extends PartialType(
+  CreateSeverityScaleDto,
+) {}

--- a/src/modules/severity-scale/severity-scale.controller.spec.ts
+++ b/src/modules/severity-scale/severity-scale.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SeverityScaleController } from './severity-scale.controller';
+import { SeverityScaleService } from './severity-scale.service';
+
+describe('SeverityScaleController', () => {
+  let controller: SeverityScaleController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SeverityScaleController],
+      providers: [SeverityScaleService],
+    }).compile();
+
+    controller = module.get<SeverityScaleController>(SeverityScaleController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/severity-scale/severity-scale.controller.spec.ts
+++ b/src/modules/severity-scale/severity-scale.controller.spec.ts
@@ -1,20 +1,165 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { UpdateSeverityScaleDto } from './dtos';
 import { SeverityScaleController } from './severity-scale.controller';
 import { SeverityScaleService } from './severity-scale.service';
 
 describe('SeverityScaleController', () => {
   let controller: SeverityScaleController;
+  let severityScaleService: SeverityScaleService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [SeverityScaleController],
-      providers: [SeverityScaleService],
+      providers: [
+        {
+          provide: SeverityScaleService,
+          useValue: {
+            getSeveritiesScale: jest.fn(),
+            getSeverityScaleById: jest.fn(),
+            createSeverityScale: jest.fn(),
+            updateSeverityScale: jest.fn(),
+            deleteSeverityScaleById: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<SeverityScaleController>(SeverityScaleController);
+    severityScaleService =
+      module.get<SeverityScaleService>(SeverityScaleService);
   });
+
+  afterEach(() => jest.clearAllMocks());
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('#getSeveritiesScale', () => {
+    it('should return all severities from db', async () => {
+      const expectedResponse = [
+        {
+          id: 'abc123',
+          name: 'minimal',
+          description: 'minimal description',
+          icon: 'minimal icon',
+        },
+      ];
+      const getSeveritiesScaleSpy = jest
+        .spyOn(severityScaleService, 'getSeveritiesScale')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await controller.getSeveritiesScale();
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(getSeveritiesScaleSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('#getSeverityScaleById', () => {
+    it('should get a specific severity from db based in the argument given', async () => {
+      const params = { id: 'abc123' };
+      const expectedResponse = {
+        id: params.id,
+        name: 'minimal',
+        description: 'minimal description',
+        icon: 'minimal icon',
+      };
+      const getSeverityScaleByIdSpy = jest
+        .spyOn(severityScaleService, 'getSeverityScaleById')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await controller.getSeverityScaleById(params.id);
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(getSeverityScaleByIdSpy).toHaveBeenCalled();
+      expect(getSeverityScaleByIdSpy).toHaveBeenCalledWith(params.id);
+    });
+  });
+
+  describe('#createSeverityScale', () => {
+    it('should create a new severity in the db', async () => {
+      const params = {
+        name: 'moderate',
+        description: 'moderate description',
+        icon: 'moderate icon',
+      };
+      const expectedResponse = {
+        id: '123abc',
+        name: params.name,
+        description: params.description,
+        icon: params.icon,
+      };
+      const createSeverityScaleSpy = jest
+        .spyOn(severityScaleService, 'createSeverityScale')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await controller.createSeverityScale(params);
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(createSeverityScaleSpy).toHaveBeenCalled();
+      expect(createSeverityScaleSpy).toHaveBeenCalledWith(
+        params.name,
+        params.description,
+        params.icon,
+      );
+    });
+  });
+
+  describe('#updateSeverityScale', () => {
+    it('should update a severity from db based in the id given as argument', async () => {
+      const paramId = '123abc';
+      const paramsBody = {
+        name: 'moderate',
+        description: 'moderate description updated',
+        icon: 'moderate icon updated',
+      } as UpdateSeverityScaleDto;
+      const expectedResponse = {
+        id: paramId,
+        name: paramsBody.name,
+        description: paramsBody.description,
+        icon: paramsBody.icon,
+      };
+      const updateSeverityScaleSpy = jest
+        .spyOn(severityScaleService, 'updateSeverityScale')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await controller.updateSeverityScale(paramId, paramsBody);
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(updateSeverityScaleSpy).toHaveBeenCalled();
+      expect(updateSeverityScaleSpy).toHaveBeenCalledWith(
+        paramId,
+        paramsBody.name,
+        paramsBody.description,
+        paramsBody.icon,
+      );
+    });
+  });
+
+  describe('#deleteSeverityScale', () => {
+    it('should delete a specific severity from db based in the argument given', async () => {
+      const params = { id: 'abc123' };
+      const expectedResponse = {
+        id: params.id,
+        name: 'minimal deleted',
+        description: 'minimal description',
+        icon: 'minimal icon',
+      };
+      const deleteSeverityScaleByIdSpy = jest
+        .spyOn(severityScaleService, 'deleteSeverityScaleById')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await controller.deleteSeverityScaleById(params.id);
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(deleteSeverityScaleByIdSpy).toHaveBeenCalled();
+      expect(deleteSeverityScaleByIdSpy).toHaveBeenCalledWith(params.id);
+    });
   });
 });

--- a/src/modules/severity-scale/severity-scale.controller.ts
+++ b/src/modules/severity-scale/severity-scale.controller.ts
@@ -1,0 +1,56 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Put,
+  Param,
+  Delete,
+} from '@nestjs/common';
+import { SeverityScaleService } from './severity-scale.service';
+import { CreateSeverityScaleDto } from './dtos/create-severity-scale.dto';
+import { UpdateSeverityScaleDto } from './dtos/update-severity-scale.dto';
+
+@Controller('severity-scale')
+export class SeverityScaleController {
+  constructor(private readonly severityScaleService: SeverityScaleService) {}
+
+  @Get()
+  public async getSeveritiesScale() {
+    return this.severityScaleService.getSeveritiesScale();
+  }
+
+  @Get('/:id')
+  public async getSeverityScaleById(@Param('id') id: string) {
+    return this.severityScaleService.getSeverityScaleById(id);
+  }
+
+  @Post()
+  public async createSeverityScale(
+    @Body() { name, description, icon }: CreateSeverityScaleDto,
+  ) {
+    return this.severityScaleService.createSeverityScale(
+      name,
+      description,
+      icon,
+    );
+  }
+
+  @Put('/:id')
+  public async updateSeverityScale(
+    @Param('id') id: string,
+    @Body() { name, description, icon }: UpdateSeverityScaleDto,
+  ) {
+    return this.severityScaleService.updateSeverityScale(
+      id,
+      name,
+      description,
+      icon,
+    );
+  }
+
+  @Delete(':id')
+  public async deleteSeverityScaleById(@Param('id') id: string) {
+    return this.severityScaleService.deleteSeverityScaleById(id);
+  }
+}

--- a/src/modules/severity-scale/severity-scale.module.ts
+++ b/src/modules/severity-scale/severity-scale.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SeverityScaleService } from './severity-scale.service';
+import { SeverityScaleController } from './severity-scale.controller';
+import { PrismaModule } from '../../shared/services/prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [SeverityScaleController],
+  providers: [SeverityScaleService],
+})
+export class SeverityScaleModule {}

--- a/src/modules/severity-scale/severity-scale.service.spec.ts
+++ b/src/modules/severity-scale/severity-scale.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SeverityScaleService } from './severity-scale.service';
+
+describe('SeverityScaleService', () => {
+  let service: SeverityScaleService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SeverityScaleService],
+    }).compile();
+
+    service = module.get<SeverityScaleService>(SeverityScaleService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/severity-scale/severity-scale.service.spec.ts
+++ b/src/modules/severity-scale/severity-scale.service.spec.ts
@@ -1,18 +1,179 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../shared/services/prisma/prisma.service';
 import { SeverityScaleService } from './severity-scale.service';
 
 describe('SeverityScaleService', () => {
   let service: SeverityScaleService;
+  let prismaService: PrismaService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [SeverityScaleService],
+      providers: [
+        SeverityScaleService,
+        {
+          provide: PrismaService,
+          useValue: {
+            severityScale: {
+              findMany: jest.fn(),
+              findFirst: jest.fn(),
+              create: jest.fn(),
+              update: jest.fn(),
+              delete: jest.fn(),
+            },
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<SeverityScaleService>(SeverityScaleService);
+    prismaService = module.get<PrismaService>(PrismaService);
   });
+
+  afterEach(() => jest.clearAllMocks());
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('#getSeveritiesScale', () => {
+    it('should return all severities scale from db', async () => {
+      const expectedResponse = [
+        {
+          id: 'abc123',
+          name: 'minimal',
+          description: 'minimal description',
+          icon: 'minimal icon',
+        },
+      ];
+      const findManySpy = jest
+        .spyOn(prismaService.severityScale, 'findMany')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await service.getSeveritiesScale();
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(findManySpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('#getSeverityScaleById', () => {
+    it('should return a specific severity from db by id given as argument', async () => {
+      const params = { id: 'abc123' };
+      const expectedResponse = {
+        id: params.id,
+        name: 'minimal',
+        description: 'minimal description',
+        icon: 'minimal icon',
+      };
+
+      const findFirstSpy = jest
+        .spyOn(prismaService.severityScale, 'findFirst')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await service.getSeverityScaleById(params.id);
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(findFirstSpy).toHaveBeenCalled();
+      expect(findFirstSpy).toHaveBeenCalledWith({ where: { id: params.id } });
+    });
+  });
+
+  describe('#createSeverityScale', () => {
+    it('should create a new severity scale in the db based in the properties given as arguments', async () => {
+      const params = {
+        name: 'moderate',
+        description: 'moderate description',
+        icon: 'moderate icon',
+      };
+      const expectedResponse = {
+        id: '123abc',
+        name: params.name,
+        description: params.description,
+        icon: params.icon,
+      };
+      const createSpy = jest
+        .spyOn(prismaService.severityScale, 'create')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await service.createSeverityScale(
+        params.name,
+        params.description,
+        params.icon,
+      );
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(createSpy).toHaveBeenCalled();
+      expect(createSpy).toHaveBeenCalledWith({
+        data: {
+          name: params.name,
+          description: params.description,
+          icon: params.icon,
+        },
+      });
+    });
+  });
+
+  describe('#updateSeverityScale', () => {
+    it('should update the properties of a severity from db', async () => {
+      const params = {
+        id: '123abc',
+        name: 'moderate',
+        description: 'moderate description updated',
+        icon: 'moderate icon updated',
+      };
+      const expectedResponse = {
+        id: params.id,
+        name: params.name,
+        description: params.description,
+        icon: params.icon,
+      };
+      const updateSpy = jest
+        .spyOn(prismaService.severityScale, 'update')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await service.updateSeverityScale(
+        params.id,
+        params.name,
+        params.description,
+        params.icon,
+      );
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(updateSpy).toHaveBeenCalled();
+      expect(updateSpy).toBeCalledWith({
+        where: { id: params.id },
+        data: {
+          name: params.name,
+          description: params.description,
+          icon: params.icon,
+        },
+      });
+    });
+  });
+
+  describe('#deleteSeverityScaleById', () => {
+    it('should delete a specific severity scale from db by id given as argument', async () => {
+      const params = { id: 'abc123' };
+      const expectedResponse = {
+        id: params.id,
+        name: 'minimal deleted',
+        description: 'minimal description',
+        icon: 'minimal icon',
+      };
+      const deleteSpy = jest
+        .spyOn(prismaService.severityScale, 'delete')
+        .mockResolvedValue(expectedResponse);
+
+      const result = await service.deleteSeverityScaleById(params.id);
+
+      expect(result).toBeDefined();
+      expect(result).toEqual(expectedResponse);
+      expect(deleteSpy).toHaveBeenCalled();
+      expect(deleteSpy).toHaveBeenCalledWith({ where: { id: params.id } });
+    });
   });
 });

--- a/src/modules/severity-scale/severity-scale.service.ts
+++ b/src/modules/severity-scale/severity-scale.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@nestjs/common';
 import { SeverityScale } from '@prisma/client';
+import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../shared/services/prisma/prisma.service';
 
 @Injectable()

--- a/src/modules/severity-scale/severity-scale.service.ts
+++ b/src/modules/severity-scale/severity-scale.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { SeverityScale } from '@prisma/client';
+import { PrismaService } from '../../shared/services/prisma/prisma.service';
+
+@Injectable()
+export class SeverityScaleService {
+  private readonly model = this.prismaService.severityScale;
+
+  constructor(private readonly prismaService: PrismaService) {}
+
+  public async getSeveritiesScale(): Promise<SeverityScale[]> {
+    return this.model.findMany();
+  }
+
+  public async getSeverityScaleById(id: string): Promise<SeverityScale> {
+    return this.model.findFirst({ where: { id } });
+  }
+
+  public async createSeverityScale(
+    name: string,
+    description: string,
+    icon: string,
+  ): Promise<SeverityScale> {
+    return this.model.create({
+      data: {
+        name,
+        description,
+        icon,
+      },
+    });
+  }
+
+  public async updateSeverityScale(
+    id: string,
+    name: string,
+    description: string,
+    icon: string,
+  ): Promise<SeverityScale> {
+    return this.model.update({
+      where: { id },
+      data: {
+        name,
+        description,
+        icon,
+      },
+    });
+  }
+
+  public async deleteSeverityScaleById(id: string): Promise<SeverityScale> {
+    return this.model.delete({
+      where: { id },
+    });
+  }
+}


### PR DESCRIPTION
## Qué?
Se implemento el CRUD para la colección Severity Scale

## Cómo?

<!--- Detalle de las tareas realizadas -->
- Se generaron los módulos, controladores y servicios asociados
- Se implementó el servicio con los métodos básicos (CRUD)
- Se implementó el controlador con endpoints para hacer uso de los métodos del servicio
- Se generaron dtos para crear y actualizar Severity Scale
- Se actualizó el request.http con los nuevos endpoints implementados
- Se agregaron los test unitarios para el servicio y controlador